### PR TITLE
fix: add missing key field in ValidateLicenseRequestMeta schema

### DIFF
--- a/keygen-openapi.yml
+++ b/keygen-openapi.yml
@@ -3123,6 +3123,10 @@ paths:
                 meta:
                   type: object
                   properties:
+                    key:
+                      type: string
+                      description: |
+                        The license key to validate.
                     nonce:
                       type: string
                       description: |
@@ -4135,7 +4139,7 @@ paths:
                           type: object
                           description: The user the machine belongs to. If authenticated as a license user, this relationship is required and must be the authenticated user.
                           properties:
-                            data:                              
+                            data:
                               type:
                                 - object
                                 - "null"
@@ -5659,7 +5663,7 @@ paths:
         required: true
         schema:
           type: string
-    
+
     get:
       tags:
         - Releases
@@ -8548,7 +8552,7 @@ components:
                 - "null"
               description: The platform of the machine.
             maxProcesses:
-              type: 
+              type:
                 - integer
                 - "null"
               format: int64


### PR DESCRIPTION
Noticed that field `key` is missing as per https://keygen.sh/docs/api/licenses/#licenses-actions-validate-key.

curl -X POST https://api.keygen.sh/v1/accounts/<account>/licenses/actions/validate-key \
```
  -H 'Content-Type: application/vnd.api+json' \
  -H 'Accept: application/vnd.api+json' \
  -d '{
        "meta": {
          "key": "C1B6DE-39A6E3-DE1529-8559A0-4AF593-V3",
          "scope": {
            "fingerprint": "4d:Eq:UV:D3:XZ:tL:WN:Bz:mA:Eg:E6:Mk:YX:dK:NC"
          }
        }
      }'
```