### PR TITLE
fix: nullability in create & update user requests

### DIFF
--- a/keygen-openapi.yml
+++ b/keygen-openapi.yml
@@ -1933,16 +1933,22 @@ paths:
                       type: object
                       properties:
                         firstName:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The first name of the user.
                         lastName:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The last name of the user.
                         email:
                           type: string
                           description: The unique email of the user.
                         password:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The password for the user.
                         role:
                           $ref: "#/components/schemas/Role"

--- a/keygen-openapi.yml
+++ b/keygen-openapi.yml
@@ -2136,16 +2136,22 @@ paths:
                       type: object
                       properties:
                         firstName:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The first name of the user.
                         lastName:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The last name of the user.
                         email:
                           type: string
                           description: The unique email of the user.
                         password:
-                          type: string
+                          type:
+                            - string
+                            - "null"
                           description: The password for the user.
                         role:
                           $ref: "#/components/schemas/Role"


### PR DESCRIPTION
The User model's `firstName`, `lastName`, and `password` fields are nullable as well as optional. The current spec only declares them as optional which prevents some generated API clients from setting these values to `null`.