### PR TITLE
feat: allow setting TTL to null on license & machine checkout

### DIFF
--- a/keygen-openapi.yml
+++ b/keygen-openapi.yml
@@ -3402,7 +3402,9 @@ paths:
           description: The time-to-live (TTL) of the checked out license file, in seconds.
           required: false
           schema:
-            type: integer
+            type:
+              - integer
+              - "null"
             format: int64
             minimum: 3600
             maximum: 31556952
@@ -4467,7 +4469,9 @@ paths:
           description: The time-to-live (TTL) of the checked out machine file, in seconds.
           required: false
           schema:
-            type: integer
+            type:
+              - integer
+              - "null"
             format: int64
             minimum: 3600
             maximum: 31556952


### PR DESCRIPTION
Both check-out endpoints allow making TTL indefinite by setting it to null.